### PR TITLE
__wip: Enable timezoned display using moment & moment-timezone

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,9 @@
 {
   "name": "smalot-bootstrap-datetimepicker",
-  "main": ["js/bootstrap-datetimepicker.min.js", "css/bootstrap-datetimepicker.min.css"],
+  "main": [
+    "js/bootstrap-datetimepicker.min.js",
+    "css/bootstrap-datetimepicker.min.css"
+  ],
   "ignore": [
     "build",
     "sample in bootstrap v2",
@@ -13,6 +16,7 @@
     "minify.sh"
   ],
   "dependencies": {
-    "moment": "~2.8.3"
+    "moment": "~2.8.3",
+    "moment-timezone": "~0.4.0"
   }
 }


### PR DESCRIPTION
Enable injecting timezones in the datetimepicker.

Still WIP, the regular buttons don't work and should ignore this.
